### PR TITLE
removed Python 3.6 import

### DIFF
--- a/sacn/receiving/receiver_thread.py
+++ b/sacn/receiving/receiver_thread.py
@@ -3,7 +3,7 @@ import threading
 import time
 import socket
 import logging
-from typing import Dict
+#from typing import Dict#requires Python 3.5
 
 from sacn.messages.data_packet import DataPacket
 from sacn.receiver import LISTEN_ON_OPTIONS, E131_NETWORK_DATA_LOSS_TIMEOUT_ms


### PR DESCRIPTION
Removed the typing import from the file, because this module is only available in Python 3.6 and higher